### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,8 @@ env:
 jobs:
   build_and_test:
     name: Build and test
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/sorcio/wireguard-docker-plugin/security/code-scanning/1](https://github.com/sorcio/wireguard-docker-plugin/security/code-scanning/1)

To resolve the issue, you should explicitly add a `permissions` block to your workflow, ensuring the GITHUB_TOKEN used by this CI pipeline only has the minimum required privilege. For build and test jobs that do not interact with the repository or create or modify issues or pull requests, this is typically `contents: read`, which allows read-only access to repository code and resources. The block should be added inside the job definition, specifically above the `runs-on:` key (line 19) for the `build_and_test` job in `.github/workflows/ci.yaml`. No new imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
